### PR TITLE
Isolate client methods

### DIFF
--- a/test/test.html
+++ b/test/test.html
@@ -4,12 +4,12 @@
   <Body>
   </Body>
   <script type="module">
-    import Client from '/src/Client.js';
+    import Client, { open } from '../src/Client.js';
 
     var client = new Client('ws://localhost:4000');
     console.log(client);
     (async () => {
-      await client.open();
+      await client[open]();
       console.log("1");
       console.log(await client.whatsUp());
       console.log("hi");


### PR DESCRIPTION
I was doing symbols for all `this.*` properties, than decided to go with a single `props` Symbol for simplicity.